### PR TITLE
fix: buildTxAddLiquidV3

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Retrieve the transaction block to add liquidity (creating new position). If the 
 ```
 import {buildTxAddLiquidV3} from "@flowx-pkg/ts-sdk"
 
-const tx: TransactionBock = await txBuild(
+const tx: TransactionBock = await buildTxAddLiquidV3(
 	coinX,
 	coinY,
 	slippage,

--- a/src/liquidity/v3/buildTxAddLiquidV3.ts
+++ b/src/liquidity/v3/buildTxAddLiquidV3.ts
@@ -9,7 +9,7 @@ import { asIntN } from "./utils";
 
 const getI32Object = (tickIndex: number, tx: TransactionBlock) => {
   return tx.moveCall({
-    target: `${ADD_LIQUIDITY_V3.CLMM_PACKAGE}::i3z2::${
+    target: `${ADD_LIQUIDITY_V3.CLMM_PACKAGE}::i32::${
       tickIndex < 0 ? "neg_from" : "from"
     }`,
     typeArguments: [],

--- a/src/liquidity/v3/getTxOpenPositionLiquidV3.ts
+++ b/src/liquidity/v3/getTxOpenPositionLiquidV3.ts
@@ -17,7 +17,7 @@ export const getTxOpenPositionLiquidV3 = async (
     arguments: [
       tx.object(ADD_LIQUIDITY_V3.POSITION_REGISTRY_OBJ),
       tx.object(ADD_LIQUIDITY_V3.POOL_REGISTRY_OBJ),
-      tx.pure(fee.valueDecimal),
+      tx.pure(fee.value),
       lowerTickIndex,
       upperTickIndex,
       tx.object(ADD_LIQUIDITY_V3.VERSIONED_OBJ),


### PR DESCRIPTION
### Issue:
- Cannot build transaction block received from buildTxAddLiquidV3

### Reproduce: 

```
import {buildTxAddLiquidV3} from "@flowx-pkg/ts-sdk"

const txb: TransactionBock = await buildTxAddLiquidV3(
    coinX,
    coinY,
    slippage,
    fee,
    lowerTick,
    upperTick,
    amountX,
    amountY,
    account
)

const bytes = await txb.build({ provider: this.client });
```

got an error:

```JsonRpcError: No module found with module name i3z2```